### PR TITLE
feat: Add support for multiple build flavors and update app name hand…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Laza Shop Dev",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main_dev.dart",
+      "args": ["--flavor", "development", "--target", "lib/main_dev.dart"]
+    },
+    {
+      "name": "Laza Shop Prod",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart",
+      "args": ["--flavor", "production", "--target", "lib/main.dart"]
+    }
+  ]
+}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -30,6 +30,27 @@ android {
         versionName = flutter.versionName
     }
 
+    flavorDimensions += "default"
+    productFlavors {
+        create("production") {
+            dimension = "default"
+            resValue(
+                type = "string",
+                name = "app_name",
+                value = "Laza Shop"
+                )
+        }
+        create("development") {
+            dimension = "default"
+            applicationIdSuffix = ".dev"
+            resValue(
+                type = "string",
+                name = "app_name",
+                value = "Laza Shop Dev"
+                )
+        }
+    }
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="laza_shop"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon">
         <activity

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:laza_shop/core/helpers/extensions.dart';
+
+import 'core/di/dependency_injection.dart';
+import 'core/helpers/constants.dart';
+import 'core/helpers/shared_pref_helper.dart';
+import 'core/routing/app_router.dart';
+import 'laza_app.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  setupGetIt();
+  await ScreenUtil.ensureScreenSize();
+  await checkIsOnboardingSeen();
+  await checkIfLoggedInUser();
+  runApp(LazaShopApp(appRouter: AppRouter()));
+}
+
+checkIfLoggedInUser() async {
+  String? userToken = await SharedPrefHelper.getSecuredString(
+    SharedPrefKeys.userToken,
+  );
+  isLoggedInUser = !userToken.isNullOrEmpty();
+  debugPrint('isLoggedInUser: $isLoggedInUser');
+}
+
+checkIsOnboardingSeen() async {
+  isOnboardingSeen = await SharedPrefHelper.getBool(SharedPrefKeys.onboarding);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ flutter_launcher_icons:
   ios: true
   image_path: "assets/images/logo.png"
   min_sdk_android: 21 # android min sdk min:16, default 21 # android min sdk min:16, default 21
-  adaptive_icon_background: "#9775FA"
+  adaptive_icon_background: "#FFFFFF"
   adaptive_icon_foreground: "assets/images/logo.png"
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
This pull request introduces support for build flavors in the Android project and sets up corresponding launch configurations for development and production environments. It also includes the necessary code and manifest changes to support these flavors, as well as a new entry point for the development flavor. Additionally, there is a minor update to the launcher icon background color.

**Android build flavor support:**

* Added `production` and `development` product flavors in `android/app/build.gradle.kts`, each with its own app name and, for development, an application ID suffix. This enables separate builds for development and production environments.
* Updated `android/app/src/main/AndroidManifest.xml` to use the `app_name` resource, allowing the app label to change based on the selected flavor.

**Development entry point and tooling:**

* Added `lib/main_dev.dart` as a new entry point for the development flavor, including initialization logic for dependency injection, onboarding status, and user authentication.
* Added `.vscode/launch.json` with launch configurations for both development and production flavors, making it easier to run the appropriate build from within VS Code.

**UI/branding update:**

* Changed the adaptive icon background color in `pubspec.yaml` from purple to white for a cleaner looking for Android