### PR TITLE
feat: Fix refresh token expiration handling and improve UI consistency

### DIFF
--- a/lib/core/helpers/constants.dart
+++ b/lib/core/helpers/constants.dart
@@ -1,5 +1,9 @@
+import 'package:flutter/material.dart';
+
 bool isLoggedInUser = false;
 bool isOnboardingSeen = false;
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 class SharedPrefKeys {
   static const String userToken = 'userToken';

--- a/lib/core/helpers/shared_pref_helper.dart
+++ b/lib/core/helpers/shared_pref_helper.dart
@@ -4,19 +4,19 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class SharedPrefHelper {
   SharedPrefHelper._();
-  static removeData(String key) async {
+  static Future<void> removeData(String key) async {
     debugPrint('SharedPrefHelper : data with key : $key has been removed');
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
     await sharedPreferences.remove(key);
   }
 
-  static clearAllData() async {
+  static Future<void> clearAllData() async {
     debugPrint('SharedPrefHelper : all data has been cleared');
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
     await sharedPreferences.clear();
   }
 
-  static setData(String key, value) async {
+  static Future<void> setData(String key, value) async {
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
     debugPrint("SharedPrefHelper : setData with key : $key and value : $value");
     switch (value.runtimeType) {
@@ -37,31 +37,31 @@ class SharedPrefHelper {
     }
   }
 
-  static getBool(String key) async {
+  static Future<bool> getBool(String key) async {
     debugPrint('SharedPrefHelper : getBool with key : $key');
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
     return sharedPreferences.getBool(key) ?? false;
   }
 
-  static getDouble(String key) async {
+  static Future<double> getDouble(String key) async {
     debugPrint('SharedPrefHelper : getDouble with key : $key');
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
     return sharedPreferences.getDouble(key) ?? 0.0;
   }
 
-  static getInt(String key) async {
+  static Future<int> getInt(String key) async {
     debugPrint('SharedPrefHelper : getInt with key : $key');
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
     return sharedPreferences.getInt(key) ?? 0;
   }
 
-  static getString(String key) async {
+  static Future<String> getString(String key) async {
     debugPrint('SharedPrefHelper : getString with key : $key');
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
     return sharedPreferences.getString(key) ?? '';
   }
 
-  static setSecuredString(String key, String value) async {
+  static Future<void> setSecuredString(String key, String value) async {
     const flutterSecureStorage = FlutterSecureStorage();
     debugPrint(
       "FlutterSecureStorage : setSecuredString with key : $key and value : $value",
@@ -69,13 +69,19 @@ class SharedPrefHelper {
     await flutterSecureStorage.write(key: key, value: value);
   }
 
-  static getSecuredString(String key) async {
+  static Future<String> getSecuredString(String key) async {
     const flutterSecureStorage = FlutterSecureStorage();
     debugPrint('FlutterSecureStorage : getSecuredString with key : $key');
     return await flutterSecureStorage.read(key: key) ?? '';
   }
 
-  static clearAllSecuredData() async {
+  static Future<void> removeSecuredString(String key) async {
+    const flutterSecureStorage = FlutterSecureStorage();
+    debugPrint('FlutterSecureStorage : removeSecuredString with key : $key');
+    await flutterSecureStorage.delete(key: key);
+  }
+
+  static Future<void> clearAllSecuredData() async {
     debugPrint('FlutterSecureStorage : all data has been cleared');
     const flutterSecureStorage = FlutterSecureStorage();
     await flutterSecureStorage.deleteAll();

--- a/lib/core/networking/dio_factory.dart
+++ b/lib/core/networking/dio_factory.dart
@@ -1,5 +1,7 @@
 import 'package:dio/dio.dart';
+import 'package:laza_shop/core/helpers/extensions.dart';
 import 'package:laza_shop/core/networking/api_services.dart';
+import 'package:laza_shop/core/routing/routes.dart';
 import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 import '../helpers/constants.dart';
 import '../helpers/shared_pref_helper.dart';
@@ -49,40 +51,84 @@ class DioFactory {
       InterceptorsWrapper(
         onError: (error, handler) async {
           if (error.response?.statusCode == 401) {
-            String? refreshToken = await SharedPrefHelper.getSecuredString(
+            final refreshToken = await SharedPrefHelper.getSecuredString(
               SharedPrefKeys.refreshToken,
             );
-            if (refreshToken != null) {
-              ApiService apiService = ApiService(DioFactory.getDio());
-              try {
-                final response = await apiService.refreshToken({
-                  'refreshToken': refreshToken,
-                });
-                String newToken = response.accessToken!;
-                SharedPrefHelper.setSecuredString(
+            if (refreshToken.isNullOrEmpty()) {
+              // No refresh token available, navigate to login
+              await SharedPrefHelper.removeSecuredString(
+                SharedPrefKeys.userToken,
+              );
+              isLoggedInUser = false;
+
+              navigatorKey.currentState?.pushNamedAndRemoveUntil(
+                Routes.loginScreen,
+                (route) => false,
+              );
+
+              return handler.reject(
+                DioException(
+                  requestOptions: error.requestOptions,
+                  error: 'Session expired. Please login again.',
+                  type: DioExceptionType.badResponse,
+                  response: error.response,
+                ),
+              );
+            }
+            final apiService = ApiService(DioFactory.getDio());
+            try {
+              final response = await apiService.refreshToken({
+                'refreshToken': refreshToken,
+              });
+              final newToken = response.accessToken!;
+
+              await SharedPrefHelper.setSecuredString(
+                SharedPrefKeys.userToken,
+                newToken,
+              );
+              await SharedPrefHelper.setSecuredString(
+                SharedPrefKeys.refreshToken,
+                response.refreshToken!,
+              );
+              DioFactory.setTokenIntoHeaderAfterLogin(newToken);
+              // Retry the original request
+              final options = error.requestOptions;
+              final cloneReq = await DioFactory.getDio().request(
+                options.path,
+                options: Options(
+                  method: options.method,
+                  headers: options.headers,
+                ),
+                data: options.data,
+                queryParameters: options.queryParameters,
+              );
+              return handler.resolve(cloneReq);
+            } catch (e) {
+              // Refresh token failed (expired or invalid)
+              if (e is DioException && e.response?.statusCode == 400) {
+                await SharedPrefHelper.removeSecuredString(
                   SharedPrefKeys.userToken,
-                  newToken,
                 );
-                SharedPrefHelper.setSecuredString(
+                await SharedPrefHelper.removeSecuredString(
                   SharedPrefKeys.refreshToken,
-                  response.refreshToken!,
                 );
-                DioFactory.setTokenIntoHeaderAfterLogin(newToken);
-                final options = error.requestOptions;
-                final cloneReq = await DioFactory.getDio().request(
-                  options.path,
-                  options: Options(
-                    method: options.method,
-                    headers: options.headers,
+                isLoggedInUser = false;
+
+                // Navigate to login screen
+                navigatorKey.currentState?.pushNamedAndRemoveUntil(
+                  Routes.loginScreen,
+                  (route) => false,
+                );
+
+                return handler.reject(
+                  DioException(
+                    requestOptions: error.requestOptions,
+                    error: 'Session expired. Please login again.',
+                    type: DioExceptionType.badResponse,
+                    response: e.response,
                   ),
-                  data: options.data,
-                  queryParameters: options.queryParameters,
                 );
-                return handler.resolve(cloneReq);
-              } catch (e) {
-                return handler.next(error);
               }
-            } else {
               return handler.next(error);
             }
           } else {

--- a/lib/features/login/ui/widgets/login_bloc_listner.dart
+++ b/lib/features/login/ui/widgets/login_bloc_listner.dart
@@ -52,7 +52,10 @@ class LoginBlocListener extends StatelessWidget {
             onPressed: () {
               context.pop();
             },
-            child: Text('Got it', style: TextStyles.font13W400),
+            child: Text(
+              'Got it',
+              style: TextStyles.font13W400.copyWith(color: Colors.white),
+            ),
           ),
         ],
       ),

--- a/lib/features/sign_up/ui/widgets/confirm_email_bloc_listner.dart
+++ b/lib/features/sign_up/ui/widgets/confirm_email_bloc_listner.dart
@@ -55,7 +55,8 @@ class ConfirmEmailBlocListener extends StatelessWidget {
             onPressed: () {
               context.pop();
             },
-            child: Text('Got it', style: TextStyles.font13W400),
+            child: Text('Got it', style: TextStyles.font13W400.copyWith(color: Colors.white),
+            ),
           ),
         ],
       ),

--- a/lib/features/sign_up/ui/widgets/signup_bloc_listner.dart
+++ b/lib/features/sign_up/ui/widgets/signup_bloc_listner.dart
@@ -59,7 +59,10 @@ class SignupBlocListener extends StatelessWidget {
             onPressed: () {
               context.pop();
             },
-            child: Text('Got it', style: TextStyles.font13W400),
+            child: Text(
+              'Got it',
+              style: TextStyles.font13W400.copyWith(color: Colors.white),
+            ),
           ),
         ],
       ),

--- a/lib/laza_app.dart
+++ b/lib/laza_app.dart
@@ -17,6 +17,7 @@ class LazaShopApp extends StatelessWidget {
       minTextAdapt: true,
       builder: (context, child) {
         return MaterialApp(
+          navigatorKey: navigatorKey,
           title: 'Accessories Shop App',
           theme: getThemeDataLight(),
           darkTheme: getThemeDataDark(),


### PR DESCRIPTION
This pull request introduces several improvements to authentication error handling, shared preferences management, and UI consistency. The main focus is on enhancing session management and navigation when authentication fails, refactoring shared preferences helper methods for clarity and robustness, and ensuring consistent button styling across the app.

**Authentication and session management enhancements:**

* Added a global `navigatorKey` in `constants.dart` and integrated it into `MaterialApp` to support navigation from non-widget contexts, such as error handlers. (`lib/core/helpers/constants.dart`, `lib/laza_app.dart`) [[1]](diffhunk://#diff-1339274590c5dbd7531d76f298f62dddaf68556ec9066cc5ccbeea2d731636cbR1-R7) [[2]](diffhunk://#diff-820a88ad5e5a3eff7709c100bb54a740634acd0ea67aea0b6598fd516326cd8dR20)
* Improved handling of expired or invalid authentication tokens in `dio_factory.dart`. Now, if a refresh token is missing or invalid, the user is automatically logged out, tokens are cleared, and navigation to the login screen is triggered. Error messages are also improved for better user feedback. (`lib/core/networking/dio_factory.dart`) [[1]](diffhunk://#diff-c6cb749a992cd4c1378511ac4f8f26883efc30233ff4a3e4faa32eeaf1c4556bL52-R94) [[2]](diffhunk://#diff-c6cb749a992cd4c1378511ac4f8f26883efc30233ff4a3e4faa32eeaf1c4556bL83-L85)

**Shared preferences and secure storage refactoring:**

* Refactored all methods in `SharedPrefHelper` to use explicit `Future` return types, improving code clarity and type safety. Added a new `removeSecuredString` method for secure storage, and updated usages to be `await`ed for proper async handling. (`lib/core/helpers/shared_pref_helper.dart`) [[1]](diffhunk://#diff-135fc313a0807e1b217cc88623236f5fe56c845e5b5880cde1c5bcb8800934acL7-R19) [[2]](diffhunk://#diff-135fc313a0807e1b217cc88623236f5fe56c845e5b5880cde1c5bcb8800934acL40-R84)

**UI consistency improvements:**

* Updated the "Got it" button styling in login, signup, and confirm email dialogs to consistently use white text, ensuring visual uniformity. (`lib/features/login/ui/widgets/login_bloc_listner.dart`, `lib/features/sign_up/ui/widgets/confirm_email_bloc_listner.dart`, `lib/features/sign_up/ui/widgets/signup_bloc_listner.dart`) [[1]](diffhunk://#diff-fa7c42e4d326eb796c9e723b1b25e3fa7db9039fff8ec5d79d3da3ac0bc43a0eL55-R58) [[2]](diffhunk://#diff-4cd54105d22a1b8a0a42d54208edf55393138b7fda02d930d5aad4936f17968cL58-R59) [[3]](diffhunk://#diff-cb8691c296da69e573c21dac95dd77a51ae00928e2825b0f5f383422119c2f88L62-R65)
[Copilot is generating a summary...]